### PR TITLE
[FM] fix untimely CSRF token renewal for Dolibarr v13.0 compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,16 @@
+# CHANGELOG FOR XXXXXX MODULE
+
+## Not Released
+
+- FIX : Untimely CSRF token renewal by js script *2021-03-30* - 1.0.1
+    Dolibarr v13 enforces CSRF protection. With each page load by the
+    user, a token is generated and embedded in any forms on the page.
+    If the token is renewed (like here by a script that includes
+    main.inc.php) AFTER the initial token was embedded on the form,
+    the token check will always fail. Therefore it is important to
+    prevent CSRF token renewal in page dependencies (scripts, css or
+    ajax backends).
+
+## 1.0.0
+
+- No ChangeLog existed for this release

--- a/core/modules/modsearchproductbykeyword.class.php
+++ b/core/modules/modsearchproductbykeyword.class.php
@@ -61,7 +61,7 @@ class modsearchproductbykeyword extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module searchproductbykeyword";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.0';
+		$this->version = '1.0.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/js/searchproductbykeyword.js.php
+++ b/js/searchproductbykeyword.js.php
@@ -1,4 +1,6 @@
 <?php
+
+    if (!defined('NOTOKENRENEWAL'))  define('NOTOKENRENEWAL', 1);
 	require '../config.php';
 
 	$langs->load('searchproductbykeyword@searchproductbykeyword');


### PR DESCRIPTION
# FIX 1.0.1
 - FIX : Untimely CSRF token renewal by js script *2021-03-30* - 1.0.1
     Dolibarr v13 enforces CSRF protection. With each page load by the user, a token is generated and embedded in any forms on the page. If the token is renewed (like here by a script that includes main.inc.php) AFTER the initial token was embedded on the form, the token check will always fail. Therefore it is important to prevent CSRF token renewal in page dependencies (scripts, css or ajax backends).
